### PR TITLE
Handle tangent.w

### DIFF
--- a/Assets/System/OGL/basic.vert
+++ b/Assets/System/OGL/basic.vert
@@ -4,7 +4,7 @@ layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aColor;
 layout (location = 2) in vec2 aTexCoords;
 layout (location = 3) in vec3 aNormal;
-layout (location = 4) in vec3 aTangent;
+layout (location = 4) in vec4 aTangent;
 
 
 out VS_OUT {
@@ -19,9 +19,9 @@ uniform mat4 projection;
 
 void main()
 {
-    vec3 T = normalize(mat3(model) * aTangent);
+    vec3 T = normalize(mat3(model) * aTangent.xyz);
     vec3 N = normalize(mat3(model) * aNormal);
-    vec3 B = normalize(cross(N, T));
+    vec3 B = normalize(cross(N, T) * -aTangent.w);
 
     vs_out.TBN = mat3(T, B, N);
     vs_out.FragPos = vec3(model * vec4(aPos, 1.0));

--- a/CruelerThanDAT/Assets/System/OGL/basic.vert
+++ b/CruelerThanDAT/Assets/System/OGL/basic.vert
@@ -4,7 +4,7 @@ layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aColor;
 layout (location = 2) in vec2 aTexCoords;
 layout (location = 3) in vec3 aNormal;
-layout (location = 4) in vec3 aTangent;
+layout (location = 4) in vec4 aTangent;
 
 
 out VS_OUT {
@@ -19,9 +19,9 @@ uniform mat4 projection;
 
 void main()
 {
-    vec3 T = normalize(mat3(model) * aTangent);
+    vec3 T = normalize(mat3(model) * aTangent.xyz);
     vec3 N = normalize(mat3(model) * aNormal);
-    vec3 B = normalize(cross(N, T));
+    vec3 B = normalize(cross(N, T) * -aTangent.w);
 
     vs_out.TBN = mat3(T, B, N);
     vs_out.FragPos = vec3(model * vec4(aPos, 1.0));

--- a/CruelerThanDAT/inc/FileNodes.h
+++ b/CruelerThanDAT/inc/FileNodes.h
@@ -1871,23 +1871,36 @@ public:
 				glBindBuffer(GL_ARRAY_BUFFER, ctdbatch->vertexBuffer);
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctdbatch->indexBuffer);
 
-				glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)0);
+				size_t curOffset = 0;
+				// Position
+				glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(0);
+				curOffset += 3 * sizeof(float);
 
-				glVertexAttribPointer(1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(CUSTOMVERTEX), (void*)(3 * sizeof(float)));
+				// Color
+				glVertexAttribPointer(1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(1);
+				curOffset += 4 * sizeof(byte);
 
-				glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)(3 * sizeof(float) + sizeof(DWORD)));
+				// UV map
+				glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(2);
+				curOffset += 2 * sizeof(float);
 
-				glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)(2 * sizeof(float) + 3 * sizeof(float) + sizeof(DWORD))); // Normals
+				// Normals
+				glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(3);
+				curOffset += 3 * sizeof(float);
 
-				glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)(2 * sizeof(float) + 3 * sizeof(float) + 3 * sizeof(float) + sizeof(DWORD))); // Normals
+				// Tangents
+				glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(4);
+				curOffset += 4 * sizeof(float);
 
-				glVertexAttribPointer(5, 2, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)(2 * sizeof(float) + 3 * sizeof(float) + 3 * sizeof(float) + 3 * sizeof(float) + sizeof(DWORD))); // Lightmap UV
+				// Lightmap UV
+				glVertexAttribPointer(5, 2, GL_FLOAT, GL_FALSE, sizeof(CUSTOMVERTEX), (void*)curOffset);
 				glEnableVertexAttribArray(2);
+				curOffset += 2 * sizeof(float);
 
 				glBindVertexArray(0);
 


### PR DESCRIPTION
Fixes a bug with Raiden's normals on the left half of the model. Solution found from https://blender.stackexchange.com/questions/220756/why-does-blender-output-vec4-tangents-for-gltf. Also slightly refactor the code defining the vertex inputs to more easily manage these parameters in the future.